### PR TITLE
Implement `SetRelativePrintPosition` (`ESC \`) and `SetRelativeVerticalPrintPositionInPageMode` (`GS \`)

### DIFF
--- a/docs/support.html
+++ b/docs/support.html
@@ -57,7 +57,7 @@
     <span class="case" data-status="passed">[ ESC T ] Select print direction in Page mode</span>
     <span class="case" data-status="skipped">[ unknown ] Turn 90° clockwise rotation mode on/off</span>
     <span class="case" data-status="passed">[ ESC W ] Set print area in Page mode</span>
-    <span class="case" data-status="skipped">[ unknown ] Set relative print position</span>
+    <span class="case" data-status="passed">[ ESC \ ] Set relative print position</span>
     <span class="case" data-status="passed">[ ESC a ] Select justification</span>
     <span class="case" data-status="passed">[ ESC c 3 ] Select paper sensor(s) to output paper-end signals</span>
     <span class="case" data-status="passed">[ ESC c 4 ] Select paper sensor(s) to stop printing</span>
@@ -180,7 +180,7 @@
     <span class="case" data-status="skipped">[ unknown ] Set left margin</span>
     <span class="case" data-status="skipped">[ unknown ] Set horizontal and vertical motion units</span>
     <span class="case" data-status="skipped">[ unknown ] Set print area width</span>
-    <span class="case" data-status="skipped">[ unknown ] Set relative vertical print position in Page mode</span>
+    <span class="case" data-status="passed">[ GS \ ] Set relative vertical print position in Page mode</span>
     <span class="case" data-status="skipped">[ unknown ] Execute macro</span>
     <span class="case" data-status="skipped">[ unknown ] Enable/disable Automatic Status Back (ASB)</span>
     <span class="case" data-status="skipped">[ unknown ] Turn smoothing mode on/off</span>

--- a/src/fieldDecorators.ts
+++ b/src/fieldDecorators.ts
@@ -116,6 +116,16 @@ function serializeU32(n: number): Buffer {
   return buf
 }
 
+function parseI16(buf: Buffer): [number, Buffer] {
+  return [buf.readInt16LE(), buf.subarray(2)]
+}
+
+function serializeI16(n: number): Buffer {
+  const buf = Buffer.alloc(2)
+  buf.writeInt16LE(n)
+  return buf
+}
+
 function sizedBufferParseFactory(name: string, offset: number): ParseMethod {
   // Caller should bind itself as this.
   function parseSizedBuffer(this: CmdBase, buf: Buffer): [Buffer, Buffer] {
@@ -188,6 +198,17 @@ export function u32(ranges: Range[]): ClassFieldDecorator {
     context.metadata.fields[context.name] = {
       parse: parseU32,
       serialize: serializeU32,
+      validate: throwIfNumberNotInRanges(ranges),
+    }
+  }
+}
+
+export function i16(ranges: Range[]): ClassFieldDecorator {
+  return (_, context) => {
+    context.metadata.fields ??= {}
+    context.metadata.fields[context.name] = {
+      parse: parseI16,
+      serialize: serializeI16,
       validate: throwIfNumberNotInRanges(ranges),
     }
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -379,7 +379,13 @@ const testCases: TestCase[] = [
       dy: 0x6789,
     },
   },
-  { cmd: new SetRelativePrintPosition() },
+  {
+    cmd: new SetRelativePrintPosition(-324),
+    bytes: Buffer.from([0x1b, 0x5c, 0xbc, 0xfe]),
+    checks: {
+      n: -324,
+    },
+  },
   {
     cmd: new SelectJustification(Justification.Center),
     bytes: Buffer.from([0x1b, 0x61, 0x01]),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -168,7 +168,7 @@ import {
   gs_cl,
   gs_cp,
   gs_cw,
-  gs_backslash,
+  SetRelativeVerticalPrintPositionInPageMode,
   gs_caret,
   gs_la,
   gs_lb,
@@ -654,7 +654,13 @@ const testCases: TestCase[] = [
   { cmd: new gs_cl() },
   { cmd: new gs_cp() },
   { cmd: new gs_cw() },
-  { cmd: new gs_backslash() },
+  {
+    cmd: new SetRelativeVerticalPrintPositionInPageMode(-32768),
+    bytes: Buffer.from([0x1d, 0x5c, 0x00, 0x80]),
+    checks: {
+      n: -32768,
+    },
+  },
   { cmd: new gs_caret() },
   { cmd: new gs_la() },
   { cmd: new gs_lb() },

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   u16,
   sizedBuffer,
   nullTerminatedBuffer,
+  i16,
 } from './fieldDecorators'
 import { CmdBase } from './cmd'
 import { ParseError, ValidationError } from './error'
@@ -868,8 +869,19 @@ export class SetPrintAreaInPageMode extends CmdBase {
 /**
  * https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/esc_backslash.html
  */
+@register(['ESC', '\\'])
 export class SetRelativePrintPosition extends CmdBase {
   static desc: string = 'Set relative print position'
+
+  // the docs are opaque but 2 byte signed are little-endian twos complement encoding (i16)
+  @i16([[-32768, 32767]])
+  n: number
+
+  constructor(n: number) {
+    super()
+    this.n = n
+    this.validate()
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -877,6 +877,7 @@ export class SetRelativePrintPosition extends CmdBase {
   @i16([[-32768, 32767]])
   n: number
 
+  // A positive number specifies movement to the right, and a negative number specifies movement to the left.
   constructor(n: number) {
     super()
     this.n = n
@@ -2010,8 +2011,19 @@ export class gs_cw extends CmdBase {
 /**
  * https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_backslash.html
  */
-export class gs_backslash extends CmdBase {
+@register(['GS', '\\'])
+export class SetRelativeVerticalPrintPositionInPageMode extends CmdBase {
   static desc: string = 'Set relative vertical print position in Page mode'
+
+  @i16([[-32768, 32767]])
+  n: number
+
+  // A positive number specifies movement downward, and a negative number specifies movement upward.
+  constructor(n: number) {
+    super()
+    this.n = n
+    this.validate()
+  }
 }
 
 /**


### PR DESCRIPTION
Also added `@i16` decorator. 

The official docs don't actually mention the encoding, so I had to spend some time double checking it is in fact a two's complement signed integer. This Python library's docs describes the two-byte encoding, but doesn't mention that it's two's complement: https://escpos.readthedocs.io/en/latest/intro.html#byte.

Their equivalence is clear if you read the bottom of this page: https://www.cs.cornell.edu/~tomf/notes/cps104/twoscomp.html#operations

## Proof:

```
Two's complement inverse of 
  0*** **** **** ****
=
 ~0*** **** **** **** + 1
(typical definition of two's complement)
= 
  1111 1111 1111 1111 -
  0*** **** **** **** + 1
(negating digits is equivalent to subtracting from 1's)
=
1 0000 0000 0000 0000 -
  0*** **** **** ****
(two-byte encoding formula in Pyramid Python ESCPOS docs)
```